### PR TITLE
AP-2826 feat: Adding new forms-user-ready event to documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,6 +379,7 @@ Depending on the function selected, the SkySlope Forms Widget can post a message
 interface SkySlopeMessage {
   status?:
     | 'forms-onboarding-complete'
+    | 'forms-user-ready'
     | 'forms-edit-contacts'
     | 'forms-download-document'
     | 'forms-create-file'


### PR DESCRIPTION
AP-2826 feat: Adding new forms-user-ready event to documentation

- adding a new forms-user-ready event that is posted for widget integrators to listen for / react to.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new event string to the message `status` union; no runtime behavior changes.
> 
> **Overview**
> Updates `readme.md` widget event documentation by adding the new `forms-user-ready` value to the `SkySlopeMessage.status` list so integrators know to listen for it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44138dd90ad847fac82b8ae8ef8da4830c483233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->